### PR TITLE
fix: add handling to update_user_by_id to allow setting enterprise to 'null' to roll users off enterprise

### DIFF
--- a/box_sdk_gen/managers/users.py
+++ b/box_sdk_gen/managers/users.py
@@ -615,6 +615,9 @@ class UsersManager:
         }
         query_params_map: Dict[str, str] = prepare_params({'fields': to_string(fields)})
         headers_map: Dict[str, str] = prepare_params({**extra_headers})
+        json_body: SerializedData = serialize(request_body)
+        if request_body['enterprise'] == 'null':
+            json_body['enterprise'] = None
         response: FetchResponse = fetch(
             ''.join(
                 [
@@ -627,7 +630,7 @@ class UsersManager:
                 method='PUT',
                 params=query_params_map,
                 headers=headers_map,
-                data=serialize(request_body),
+                data=json_body,
                 content_type='application/json',
                 response_format='json',
                 auth=self.auth,


### PR DESCRIPTION
Added handling to the `update_user_by_id` to allow the string `"null"` for `enterprise` to properly clear the enterprise as per the api documentation. I'm unsure where else this pattern may exist, but it seems that the sdk generally does not allow users to "clear" values since the `serialize` method always filters out values set to None. This PR only addresses this one use case through direct handling of the `enterprise` request body parameter. 