### PR TITLE
Add timeout to BoxNetworkClient

### DIFF
--- a/box_sdk_gen/networking/box_network_client.py
+++ b/box_sdk_gen/networking/box_network_client.py
@@ -57,9 +57,10 @@ class APIResponse:
 
 
 class BoxNetworkClient(NetworkClient):
-    def __init__(self, requests_session: Optional[Session] = None):
+    def __init__(self, requests_session: Optional[Session] = None, timeout: Optional[float] = None):
         super().__init__()
         self.requests_session = requests_session or requests.Session()
+        self.timeout = timeout
 
     def fetch(self, options: 'FetchOptions') -> FetchResponse:
         retry_strategy = (
@@ -230,6 +231,7 @@ class BoxNetworkClient(NetworkClient):
                 params=request.params,
                 allow_redirects=request.allow_redirects,
                 stream=True,
+                timeout=self.timeout,
             )
         except RequestException as request_exc:
             raised_exception = request_exc

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,7 @@
 
 - [Max retry attempts](#max-retry-attempts)
 - [Custom retry strategy](#custom-retry-strategy)
+- [Network Timeout](#network-timeout)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -62,5 +63,23 @@ class CustomRetryStrategy(RetryStrategy):
 
 auth = BoxDeveloperTokenAuth(token="DEVELOPER_TOKEN_GOES_HERE")
 network_session = NetworkSession(retry_strategy=CustomRetryStrategy())
+client = BoxClient(auth=auth, network_session=network_session)
+```
+
+## Network Timeout
+
+The default timeout of an API call is infinite.
+To change this timeout you should initialize `BoxNetworkClient` with the new value and pass it to `NetworkSession`.
+
+```python
+from box_sdk_gen import (
+    BoxClient,
+    BoxDeveloperTokenAuth,
+    NetworkSession,
+    BoxNetworkClient,
+)
+
+auth = BoxDeveloperTokenAuth(token="DEVELOPER_TOKEN_GOES_HERE")
+network_session = NetworkSession(network_client=BoxNetworkClient(timeout=10))
 client = BoxClient(auth=auth, network_session=network_session)
 ```


### PR DESCRIPTION
Occasionally I have seen network requests fail to return and hang a program.

This adds an optional timeout to be used by the requests library as recommended by their documentation (https://docs.python-requests.org/en/latest/user/quickstart/#timeouts)

It would probably be better to include a default timeout of a few minutes, but that could introduce additional errors to handle.  So, instead this change maintains the existing behavior if a timeout is not provided.